### PR TITLE
added ability to cancel retries in unit tests

### DIFF
--- a/src/main/groovy/com/netflix/glisten/FutureAsPromise.groovy
+++ b/src/main/groovy/com/netflix/glisten/FutureAsPromise.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.glisten
+
+import com.amazonaws.services.simpleworkflow.flow.core.Promise
+import groovy.transform.Canonical
+import java.util.concurrent.Future
+
+/**
+ * Wraps a Future and makes it look like an SWF Promise. This is useful for local implementations sufficient to run unit
+ * tests without a real SWF dependency. Calls to get() will block like a Future rather than fail like an SWF Promise.
+ */
+@Canonical
+class FutureAsPromise<T> extends Promise<T> {
+    
+    final Future<T> future
+
+    @Override
+    T get() {
+        future.get()
+    }
+
+    @Override
+    boolean isReady() {
+        future.isDone()
+    }
+
+    @Override
+    protected void addCallback(Runnable callback) {
+        // no need to implement for unit tests
+    }
+
+    @Override
+    protected void removeCallback(Runnable callback) {
+        // no need to implement for unit tests
+    }
+
+    String toString() {
+        "FutureAsPromise [value=${ready ? get() : 'null'}, ready=${ready}]"
+    }
+}

--- a/src/main/groovy/com/netflix/glisten/LocalDoTry.groovy
+++ b/src/main/groovy/com/netflix/glisten/LocalDoTry.groovy
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.glisten
 
+package com.netflix.glisten
 import com.amazonaws.services.simpleworkflow.flow.core.Promise
 import com.amazonaws.services.simpleworkflow.flow.core.Settable
 
@@ -65,6 +65,9 @@ class LocalDoTry implements DoTry {
 
     @Override
     void cancel(Throwable cause) {
+        if (result instanceof FutureAsPromise) {
+            result.future.cancel(true)
+        }
     }
 
     @Override

--- a/src/main/groovy/com/netflix/glisten/LocalWorkflowOperations.groovy
+++ b/src/main/groovy/com/netflix/glisten/LocalWorkflowOperations.groovy
@@ -20,12 +20,18 @@ import com.amazonaws.services.simpleworkflow.flow.core.Promise
 import com.amazonaws.services.simpleworkflow.flow.core.Settable
 import com.amazonaws.services.simpleworkflow.flow.interceptors.RetryPolicy
 import groovy.transform.Canonical
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
 
 /**
  * Local implementation sufficient to run unit tests without a real SWF dependency.
  */
 @Canonical
 class LocalWorkflowOperations<A> extends WorkflowOperations<A> {
+    
+    private final ExecutorService pool = Executors.newFixedThreadPool(10)
 
     final A activities
 
@@ -75,28 +81,48 @@ class LocalWorkflowOperations<A> extends WorkflowOperations<A> {
     }
 
     @Override
+    @SuppressWarnings('CatchThrowable')
     <T> Promise<T> retry(RetryPolicy retryPolicy, Closure<? extends Promise<T>> work) {
         int maximumAttempts = FlowDefaults.EXPONENTIAL_RETRY_MAXIMUM_ATTEMPTS
         if (retryPolicy.respondsTo('getMaximumAttempts')) {
             maximumAttempts = retryPolicy.maximumAttempts
         }
-        recursingRetry(retryPolicy, work, maximumAttempts, 1)
+        try {
+            return work()
+        } catch (Throwable t) {
+            // Retry after first attempt fails.
+            Closure<Promise<T>> retryAttempt = {
+                recursingRetry(retryPolicy, work, maximumAttempts, 2, t)
+            }
+            if (maximumAttempts > 0) {
+                return retryAttempt()
+            }
+            // Use a future for retries if there is no maximum for retry attempts. This allows the retry to be canceled.
+            Future<Promise> futurePromiseResult = pool.submit(new Callable<Promise>() {
+                @Override
+                Promise call() throws Exception {
+                    retryAttempt()
+                }
+            })
+            return new FutureAsPromise(futurePromiseResult)
+        }
     }
 
     @SuppressWarnings('CatchThrowable')
     private <T> Promise<T> recursingRetry(RetryPolicy retryPolicy, Closure<? extends Promise<T>> work,
-            int maximumAttempts, int attemptCount, Throwable t1 = null) {
-        if (maximumAttempts > 0 && attemptCount > maximumAttempts) {
+            int maximumAttempts, int attemptCount, Throwable t1) {
+        if (Thread.currentThread().interrupted) {
+            throw new InterruptedException("Retry was interrupted on attempt ${attemptCount}.")
+        }
+        boolean abortRetry = t1 instanceof InterruptedException || !retryPolicy.isRetryable(t1) ||
+                (maximumAttempts > 0 && attemptCount > maximumAttempts)
+        if (abortRetry) {
             throw t1
         }
-        if (!t1 || retryPolicy.isRetryable(t1)) {
-            try {
-                return work()
-            } catch (Throwable t2) {
-                recursingRetry(retryPolicy, work, maximumAttempts, attemptCount + 1, t2)
-            }
-        } else {
-            throw t1
+        try {
+            return work()
+        } catch (Throwable t2) {
+            recursingRetry(retryPolicy, work, maximumAttempts, attemptCount + 1, t2)
         }
     }
 }

--- a/src/main/groovy/com/netflix/glisten/example/trip/BayAreaTripWorkflowImpl.groovy
+++ b/src/main/groovy/com/netflix/glisten/example/trip/BayAreaTripWorkflowImpl.groovy
@@ -70,7 +70,11 @@ class BayAreaTripWorkflowImpl implements BayAreaTripWorkflow {
         // take time to stretch before hiking
         status 'And stretched for 10 seconds before hiking.'
         waitFor(timer(10)) {
-            DoTry<String> hiking = doTry { promiseFor(activities.hike('through redwoods')) }
+            DoTry<String> hiking = doTry {
+                retry {
+                    promiseFor(activities.hike('through redwoods'))
+                }
+            }
             DoTry<Void> countDown = cancellableTimer(30)
             // hike until done or out of time (which ever comes first)
             waitFor(anyPromises(countDown.result, hiking.result)) {

--- a/src/test/groovy/com/netflix/glisten/example/trip/BayAreaTripWorkflowSpec.groovy
+++ b/src/test/groovy/com/netflix/glisten/example/trip/BayAreaTripWorkflowSpec.groovy
@@ -58,6 +58,9 @@ class BayAreaTripWorkflowSpec extends Specification {
 
     def 'should go to Redwoods and hike until out of time'() {
         workflowOperations.timerHasFiredSequence = [true, true]
+        mockActivities.hike('through redwoods') >> {
+            throw new IllegalStateException('got to see what is around the next bend')
+        }
 
         when:
         workflow.start('Clay', [BayAreaLocation.GoldenGateBridge])
@@ -68,9 +71,7 @@ class BayAreaTripWorkflowSpec extends Specification {
                 'And stretched for 10 seconds before hiking.',
                 'And ran out of time when hiking.'
         ]
-        0 * _
         then: 1 * mockActivities.goTo('Clay', BayAreaLocation.Redwoods) >> 'Clay went to Muir Woods.'
-        then: 1 * mockActivities.hike('through redwoods') >> null
     }
 
     def 'should go to Boardwalk and win game'() {


### PR DESCRIPTION
This is needed for retries with arbitrary max attempts so that they are not able block workflows in unit tests that retry forever (or until a time out).
